### PR TITLE
feat(firewall-policy): support for new EA network firewall policies

### DIFF
--- a/GetFirewallPolicies.bru
+++ b/GetFirewallPolicies.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: https://{{udm-ip}}/proxy/network/api/s/default/rest/firewallrule
+  url: https://{{udm-ip}}/proxy/network/v2/api/site/default/firewall-policies
   body: none
   auth: none
 }

--- a/GetFirewallPolicies.bru
+++ b/GetFirewallPolicies.bru
@@ -1,11 +1,11 @@
 meta {
-  name: GetFirewallRule
+  name: GetFirewallPolicies
   type: http
-  seq: 6
+  seq: 2
 }
 
 get {
-  url: https://{{udm-ip}}/proxy/network/api/s/default/rest/firewallrule/{{rule-id}}
+  url: https://{{udm-ip}}/proxy/network/api/s/default/rest/firewallrule
   body: none
   auth: none
 }
@@ -13,11 +13,9 @@ get {
 headers {
   x-csrf-token: {{csrf-token}}
   Cookie: {{cookie}}
-  Content-Type: application/json
 }
 
 vars:pre-request {
-  rule-id: 
   csrf-token: bru.getEnvVar("csrf-token")
   cookie: bru.getEnvVar("cookie")
 }

--- a/GetFirewallPolicy.bru
+++ b/GetFirewallPolicy.bru
@@ -1,11 +1,11 @@
 meta {
-  name: GetFirewallRule
+  name: GetFirewallPolicy
   type: http
-  seq: 6
+  seq: 3
 }
 
 get {
-  url: https://{{udm-ip}}/proxy/network/api/s/default/rest/firewallrule/{{rule-id}}
+  url: https://{{udm-ip}}/proxy/network/v2/api/site/default/firewall-policies/{{rule-id}}
   body: none
   auth: none
 }

--- a/GetFirewallRules.bru
+++ b/GetFirewallRules.bru
@@ -1,7 +1,7 @@
 meta {
   name: GetFirewallRules
   type: http
-  seq: 2
+  seq: 5
 }
 
 get {

--- a/GetTrafficRoutes.bru
+++ b/GetTrafficRoutes.bru
@@ -1,7 +1,7 @@
 meta {
   name: GetTrafficRoutes
   type: http
-  seq: 10
+  seq: 11
 }
 
 get {

--- a/GetTrafficRule.bru
+++ b/GetTrafficRule.bru
@@ -1,7 +1,7 @@
 meta {
   name: GetTrafficRule
   type: http
-  seq: 6
+  seq: 9
 }
 
 get {

--- a/GetTrafficRules.bru
+++ b/GetTrafficRules.bru
@@ -1,7 +1,7 @@
 meta {
   name: GetTrafficRules
   type: http
-  seq: 5
+  seq: 8
 }
 
 get {

--- a/ToggleFirewalPolicy.bru
+++ b/ToggleFirewalPolicy.bru
@@ -1,12 +1,12 @@
 meta {
-  name: GetFirewallRule
+  name: ToggleFirewalPolicy
   type: http
-  seq: 6
+  seq: 4
 }
 
-get {
-  url: https://{{udm-ip}}/proxy/network/api/s/default/rest/firewallrule/{{rule-id}}
-  body: none
+put {
+  url: https://{{udm-ip}}/proxy/network/v2/api/site/default/firewall-policies/{{rule-id}}
+  body: json
   auth: none
 }
 
@@ -14,6 +14,7 @@ headers {
   x-csrf-token: {{csrf-token}}
   Cookie: {{cookie}}
   Content-Type: application/json
+  Accept: application/json
 }
 
 vars:pre-request {

--- a/ToggleFirewallRule.bru
+++ b/ToggleFirewallRule.bru
@@ -1,7 +1,7 @@
 meta {
   name: ToggleFirewallRule
   type: http
-  seq: 4
+  seq: 7
 }
 
 put {

--- a/ToggleTrafficRoute.bru
+++ b/ToggleTrafficRoute.bru
@@ -1,7 +1,7 @@
 meta {
   name: ToggleTrafficRoute
   type: http
-  seq: 11
+  seq: 12
 }
 
 put {

--- a/ToggleTrafficRule.bru
+++ b/ToggleTrafficRule.bru
@@ -1,7 +1,7 @@
 meta {
   name: ToggleTrafficRule
   type: http
-  seq: 7
+  seq: 10
 }
 
 put {


### PR DESCRIPTION
Must be on v9 of the Unifi Network application

- new api requests to get all firewall policies, which is now a combined list of firewall rules and traffic rules
- get all rules, get rule, and modify rule all supported and verified.